### PR TITLE
Remove python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
@@ -11,7 +10,6 @@ env:
   - DJANGO=django==1.7.8
   - DJANGO=django==1.8.2
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install importlib argparse; fi
   - pip install $DJANGO
   - pip install -r requirements.txt
 # Test behave_django with behave :)
@@ -19,10 +17,6 @@ install:
 script: python manage.py behave --tags=~@failing && python tests.py
 matrix:
   exclude:
-   - python: "2.6"
-     env: DJANGO=django==1.7.8
-   - python: "2.6"
-     env: DJANGO=django==1.8.2
    - python: "3.3"
      env: DJANGO=django==1.4.20
    - python: "3.4"

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ behave-django is tested on:
 
 Django 1.4.20, 1.5.12, 1.6.11, 1.7.7, 1.8
 
-Python 2.6, 2.7, 3.3, 3.4
+Python 2.7, 3.3, 3.4
 
 It should work on everything, basically.
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',


### PR DESCRIPTION
I suggest removing support for python 2.6, since it is
outdated and no longer support by the Python project,
or by Django.

This will also help with the test failures on travis on old
python/django versions.
