### PR TITLE
Remove docstring available in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,14 @@ Features
 -  Use behave's configuration file
 -  Fixture loading
 
+Support
+-------
+
+behave-django supports all current Django and Python versions.
+Specifically, our tests cover:
+
+Django 1.4.20, 1.5.12, 1.6.11, 1.7.8, 1.8.2, and Python 2.6, 2.7, 3.3, 3.4.
+
 Installation
 ------------
 
@@ -75,37 +83,20 @@ Run ``python manage.py behave``
     Took.010s
     Destroying test database for alias 'default'...
 
-What's next?
-------------
+Documentation
+-------------
 
-`Read the docs!`_
+-  Documentation is available from `pythonhosted.org/behave-django`_
+-  Read more about *behave* at `pythonhosted.org/behave`_
+
+How to Contribute
+-----------------
+
+Please, read the `contributing guide`_.
 
 
-Support
--------
-
-behave-django is tested on:
-
-Django 1.4.20, 1.5.12, 1.6.11, 1.7.8, 1.8.2
-
-Python 2.6, 2.7, 3.3, 3.4
-
-It should work on everything, basically.
-
-Contributing
-------------
-
-Read the `contributing guide`_
-
-Resources
----------
-
--  `behave-django documentation`_
--  `behave`_
-
-.. _behave-django documentation: https://pythonhosted.org/behave-django/
-.. _Read the docs!: https://pythonhosted.org/behave-django/
-.. _behave: https://github.com/behave/behave
+.. _pythonhosted.org/behave-django: https://pythonhosted.org/behave-django/
+.. _pythonhosted.org/behave: http://pythonhosted.org/behave/
 .. _contributing guide: https://github.com/mixxorz/behave-django/blob/master/CONTRIBUTING.md
 .. |Build Status| image:: https://travis-ci.org/mixxorz/behave-django.svg?branch=master
    :target: https://travis-ci.org/mixxorz/behave-django

--- a/behave_django/environment.py
+++ b/behave_django/environment.py
@@ -2,6 +2,7 @@ from django.core.management import call_command
 try:
     from django.shortcuts import resolve_url
 except ImportError:
+    # support Django 1.4, which has no resolve_url() yet
     from django.shortcuts import redirect
     resolve_url = lambda to, *args, **kwargs: \
         redirect(to, *args, **kwargs)['Location']
@@ -24,17 +25,6 @@ def before_scenario(context, scenario):
     context.base_url = context.test.live_server_url
 
     def get_url(to=None, *args, **kwargs):
-        """
-        URL helper attached to context with built-in reverse resolution as a
-        handy shortcut.  Takes an absolute path, a view name, or a model
-        instance as an argument (as django.shortcuts.resolve_url).  Examples::
-
-            context.get_url()
-            context.get_url('/absolute/url/here')
-            context.get_url('view-name')
-            context.get_url('view-name', 'with args', and='kwargs')
-            context.get_url(model_instance)
-        """
         return context.base_url + (
             resolve_url(to, *args, **kwargs) if to else '')
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,10 +5,13 @@ Web Browser Automation
 ----------------------
 
 You can access the test HTTP server from your preferred web automation
-library via ``context.base_url``. Normally, this would be set to
-``http://localhost:8081``.
+library via ``context.base_url`` (normally, this would be set to
+``http://localhost:8081``).  Alternatively, you can use
+``context.get_url()``, which is a helper function for absolute paths and
+reversing URLs in your Django project.  It takes an absolute path, a view
+name, or a model as an argument, similar to `django.shortcuts.redirect`_.
 
-Example:
+Examples:
 
 .. code:: python
 
@@ -17,31 +20,24 @@ Example:
     def visit(context, url):
         context.browser.visit(context.base_url + url)
 
-Alternatively, there is a helper function ``context.get_url()`` that
-helps you get absolute URLs for your Django project. It takes an
-absolute path, a view name, or a model as an argument, similar to
-`django.shortcuts.redirect`_.
-
-Examples
-
 .. code:: python
 
+    # Get context.base_url
     context.get_url()
-    # Returns context.base_url
+    # Get context.base_url + '/absolute/url/here'
     context.get_url('/absolute/url/here')
-    # Returns context.base_url + '/absolute/url/here'
+    # Get context.base_url + reverse('view-name')
     context.get_url('view-name')
-    # Returns context.base_url + reverse('view-name')
+    # Get context.base_url + reverse('view-name', 'with args', and='kwargs')
     context.get_url('view-name', 'with args', and='kwargs')
-    # Returns context.base_url + reverse('view-name', 'with args', and='kwargs')
+    # Get context.base_url + model_instance.get_absolute_url()
     context.get_url(model_instance)
-    # Returns context.base_url + model_instance.get_absolute_url()
 
 Database transactions per scenario
 ----------------------------------
 
 Each scenario is run inside a database transaction, just like your
-regular TestCases. So you can do something like:
+regular TestCases.  So you can do something like:
 
 .. code:: python
 
@@ -50,7 +46,7 @@ regular TestCases. So you can do something like:
         # This won't be here for the next scenario
         User.objects.create_user(username=username, password-'correcthorsebatterystaple')
 
-And you don’t have to clean the database yourself. :grinning:
+And you don’t have to clean the database yourself.  :grinning:
 
 If you have `factories`_ you want to instantiate on a per-scenario basis,
 you can initialize them in ``environment.py`` like this:
@@ -59,8 +55,8 @@ you can initialize them in ``environment.py`` like this:
 
     from behave_django import environment
     from myapp.main.tests.factories import UserFactory, RandomContentFactory
-    
-    
+
+
     def before_scenario(context, scenario):
         environment.before_scenario(context, scenario)
         UserFactory(username='user1')
@@ -73,8 +69,8 @@ Note that the factories are instantiated *after* the call to
 Django’s testing client
 -----------------------
 
-Attached to the context is an instance of TestCase. You can access it
-via ``context.test``. This means you can do things like use Django’s
+Attached to the context is an instance of TestCase.  You can access it
+via ``context.test``.  This means you can do things like use Django’s
 testing client.
 
 .. code:: python
@@ -109,9 +105,9 @@ management command.
 Behave configuration file
 -------------------------
 
-You can use behave’s configuration file. Just create a
+You can use behave’s configuration file.  Just create a
 ``behave.ini``/``.behaverc`` file in your project’s root directory and
-behave will pick it up. You can read more about it `here`_.
+behave will pick it up.  You can read more about it `here`_.
 
 For example, if you want to have your features directory somewhere else.
 In your .behaverc file, you can put
@@ -127,7 +123,7 @@ Behave should now look for your features in those folders.
 Fixture loading
 ---------------
 
-behave-django can load your fixtures for you per feature/scenario. In
+behave-django can load your fixtures for you per feature/scenario.  In
 ``environment.py``, before the call to behave-django’s
 ``environment.before_scenario()``, we can load our context with the
 fixtures array.


### PR DESCRIPTION
- Reorder infos in README for what I expect newcomers to first look for
- Add comment for Django 1.4 support, and remove docstring (information is available from the documentation now)
- Make `get_url()` more prominent and its usage more clear in docs
- reST formatting: additional spacing after end of sentence (best practice in reStructuredText)
