### PR TITLE
Make docs index more DRY

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,12 @@
 behave-django
 =============
+.. intro-marker
 
 |Build Status| |Latest Version|
 
 Behave BDD integration for Django
 
+.. features-marker
 Features
 --------
 
@@ -16,6 +18,7 @@ Features
 -  Use behave's configuration file
 -  Fixture loading
 
+.. support-marker
 Support
 -------
 
@@ -24,6 +27,7 @@ Specifically, our tests cover:
 
 Django 1.4.20, 1.5.12, 1.6.11, 1.7.8, 1.8.2, and Python 2.6, 2.7, 3.3, 3.4.
 
+.. install-marker
 Installation
 ------------
 
@@ -83,12 +87,14 @@ Run ``python manage.py behave``
     Took.010s
     Destroying test database for alias 'default'...
 
+.. docs-marker
 Documentation
 -------------
 
 -  Documentation is available from `pythonhosted.org/behave-django`_
 -  Read more about *behave* at `pythonhosted.org/behave`_
 
+.. contribute-marker
 How to Contribute
 -----------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,8 @@ Welcome to behave-django's documentation!
 =========================================
 
 .. include:: ../README.rst
-   :start-after: behave-django
-   :end-before: Support
+   :start-after: .. intro-marker
+   :end-before: .. support-marker
 
 Contents
 --------
@@ -14,18 +14,12 @@ Contents
    installation
    usage
 
-Support
--------
+.. include:: ../README.rst
+   :start-after: .. support-marker
+   :end-before: .. install-marker
 
 .. include:: ../README.rst
-   :start-after: Support
-   :end-before: Installation
-
-How to Contribute
------------------
-
-.. include:: ../README.rst
-   :start-after: How to Contribute
+   :start-after: .. contribute-marker
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,25 +1,9 @@
-.. behave-django documentation master file, created by
-   sphinx-quickstart on Tue Jun  9 15:52:13 2015.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Welcome to behave-django's documentation!
 =========================================
 
-|Build Status| |Latest Version|
-
-Behave BDD integration for Django
-
-Features
---------
-
--  Web Browser Automation ready
--  Database transactions per scenario
--  Use Django's testing client
--  Use unittest + Django assert library
--  Use behave's command line arguments
--  Use behave's configuration file
--  Fixture loading
+.. include:: ../README.rst
+   :start-after: behave-django
+   :end-before: Support
 
 Contents
 --------
@@ -33,27 +17,18 @@ Contents
 Support
 -------
 
-behave-django is tested on:
+.. include:: ../README.rst
+   :start-after: Support
+   :end-before: Installation
 
-Django 1.4.20, 1.5.12, 1.6.11, 1.7.8, 1.8.2
+How to Contribute
+-----------------
 
-Python 2.6, 2.7, 3.3, 3.4
-
-It should work on everything, basically.
-
-Contributing
-------------
-
-Read the `contributing guide`_
+.. include:: ../README.rst
+   :start-after: How to Contribute
 
 Indices and tables
 ==================
 
 * :ref:`genindex`
 * :ref:`search`
-
-.. _contributing guide: https://github.com/mixxorz/behave-django/blob/master/CONTRIBUTING.md
-.. |Build Status| image:: https://travis-ci.org/mixxorz/behave-django.svg?branch=master
-   :target: https://travis-ci.org/mixxorz/behave-django
-.. |Latest Version| image:: https://badge.fury.io/py/behave-django.svg
-    :target: http://badge.fury.io/py/behave-django


### PR DESCRIPTION
Includes content from the README file instead of duplicating it.
## Notes
- With my local docs generation I've seen the resulting design of the included subsection headers is different (header is underlined), although I've not seen a difference in the HTML markup compared to the other headers in the index document. Maybe you could double-check.
- I've not seen a way to include also the subsection titles. This could make the code even more DRY.
