### PR TITLE
Make running tests available via setup.py (setuptools)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ env:
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install importlib argparse; fi
   - pip install $DJANGO
-  - pip install -r requirements.txt
-# Test behave_django with behave :)
-# Skip the failing test case
+  - pip install -r requirements-dev.txt
+# Test behave_django with behave :)  First, skip the failing test case
 script: python manage.py behave --tags=~@failing && python tests.py
 matrix:
   exclude:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 
 # testing (e.g. `python setup.py -q test -v`)
 flake8
+py.test
 
 # docs generation (e.g. `cd docs && make html`)
 Sphinx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+-r requirements.txt
+
+# testing (e.g. `python setup.py -q test -v`)
+flake8
+
+# docs generation (e.g. `cd docs && make html`)
+Sphinx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 
 # testing (e.g. `python setup.py -q test -v`)
 flake8
-py.test
+pytest
 
 # docs generation (e.g. `cd docs && make html`)
 Sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [behave]
-paths=features/
-      test_app/features/
-
+paths = features/
+        test_app/features/
 [flake8]
-exclude=docs/*
+exclude = docs/*
+[pytest]
+python_files = tests.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,5 @@
 paths=features/
       test_app/features/
 
+[flake8]
+exclude=docs/*

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,7 @@ setup(
     author_email='mixxorz@gmail.com',
     maintainer='Mitchel Cabuloy',
     maintainer_email='mixxorz@gmail.com',
-    install_requires=[
-        'behave',
-        'Django>=1.4',
-    ],
+    install_requires=open('requirements.txt').read().split(),
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -47,4 +47,5 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Testing',
     ],
+    test_suite='tests',
 )

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,10 @@
 """
 Test suite for behave-django.  See features folder for implementation.
-Run it by ``python setup.py -q test -v`` or ``python manage.py test``.
+Run it by
+
+- ``python setup.py -q test -v`` or
+- ``python manage.py test`` or
+- ``python tests.py`` (preferred)
 """
 import os
 import subprocess

--- a/tests.py
+++ b/tests.py
@@ -5,6 +5,7 @@ Run it by
 - ``python setup.py -q test -v`` or
 - ``python manage.py test`` or
 - ``python tests.py`` (preferred)
+- ``py.test -q``
 """
 import os
 import subprocess
@@ -13,25 +14,26 @@ import unittest
 
 def run_silently(command):
     FNULL = open(os.devnull, 'w')
-    exit_code = subprocess.call(
+    exit_status = subprocess.call(
         command, stdout=FNULL, stderr=subprocess.STDOUT)
     FNULL.close()
-    return exit_code
+    return exit_status
 
 
 class BehaveDjangoTestCase(unittest.TestCase):
     def test_command_should_exit_zero_if_passing(self):
-        self.assertEqual(0, run_silently(
-            ['python', 'manage.py', 'behave', '--tags', '~@failing']
-        ))
+        exit_status = run_silently(
+            ['python', 'manage.py', 'behave', '--tags', '~@failing'])
+        assert exit_status == 0
 
     def test_command_should_exit_nonzero_if_failing(self):
-        self.assertNotEqual(0, run_silently(
-            ['python', 'manage.py', 'behave', '--tags', '@failing'],
-        ))
+        exit_status = run_silently(
+            ['python', 'manage.py', 'behave', '--tags', '@failing'])
+        assert exit_status != 0
 
     def test_flake8(self):
-        self.assertEqual(0, run_silently('flake8'))
+        exit_status = run_silently('flake8')
+        assert exit_status == 0
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -1,27 +1,34 @@
+"""
+Test suite for behave-django.  See features folder for implementation.
+Run it by ``python setup.py -q test -v`` or ``python manage.py test``.
+"""
 import os
 import subprocess
 import unittest
 
 
-class BehaveDjangoTestCase(unittest.TestCase):
+def run_silently(command):
+    FNULL = open(os.devnull, 'w')
+    exit_code = subprocess.call(
+        command, stdout=FNULL, stderr=subprocess.STDOUT)
+    FNULL.close()
+    return exit_code
 
+
+class BehaveDjangoTestCase(unittest.TestCase):
     def test_command_should_exit_zero_if_passing(self):
-        FNULL = open(os.devnull, 'w')
-        return_code = subprocess.call(
-            ['python', 'manage.py', 'behave', '--tags', '~@failing'],
-            stdout=FNULL,
-            stderr=subprocess.STDOUT)
-        FNULL.close()
-        self.assertEqual(return_code, 0)
+        self.assertEqual(0, run_silently(
+            ['python', 'manage.py', 'behave', '--tags', '~@failing']
+        ))
 
     def test_command_should_exit_nonzero_if_failing(self):
-        FNULL = open(os.devnull, 'w')
-        return_code = subprocess.call(
+        self.assertNotEqual(0, run_silently(
             ['python', 'manage.py', 'behave', '--tags', '@failing'],
-            stdout=FNULL,
-            stderr=subprocess.STDOUT)
-        FNULL.close()
-        self.assertNotEqual(return_code, 0)
+        ))
+
+    def test_flake8(self):
+        self.assertEqual(0, run_silently('flake8'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Integrate all tests of `tests.py` as test suite in setuptools
- Add `flake8` as a test (so it won't be forgotten to run)
- Add flake8 configuration to the project
- Refactor and explain tests module (docstring)
- Add development requirements (tests + docs generation)
