### PR TITLE
Improved tests. Added docs. Added deprecation warnings.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,7 @@ behave-django
 Behave BDD integration for Django
 
 .. features-marker
+
 Features
 --------
 
@@ -86,6 +87,10 @@ Run ``python manage.py behave``
     3 steps passed, 0 failed, 0 skipped, 0 undefined
     Took.010s
     Destroying test database for alias 'default'...
+
+.. note::
+
+   Starting with version ``0.2.0``, you no longer need to insert the ``environment.before_scenario()`` and ``environment.after_scenario()`` functions in your ``environment.py`` file. The hooks are now included via monkey patching.
 
 .. docs-marker
 Documentation

--- a/behave_django/environment.py
+++ b/behave_django/environment.py
@@ -70,8 +70,10 @@ def monkey_patch_behave(django_test_runner):
 
 
 def before_scenario(*args, **kwargs):
-    warnings.warn("DEPRECATED: This function is no longer needed.")
+    warnings.warn("DEPRECATED: This function is no longer needed.",
+                  stacklevel=2)
 
 
 def after_scenario(*args, **kwargs):
-    warnings.warn("DEPRECATED: This function is no longer needed.")
+    warnings.warn("DEPRECATED: This function is no longer needed.",
+                  stacklevel=2)

--- a/behave_django/environment.py
+++ b/behave_django/environment.py
@@ -1,3 +1,5 @@
+import warnings
+
 from behave.runner import ModelRunner
 from django.core.management import call_command
 
@@ -65,3 +67,11 @@ def monkey_patch_behave(django_test_runner):
             django_test_runner.after_scenario(context)
 
     ModelRunner.run_hook = run_hook
+
+
+def before_scenario(*args, **kwargs):
+    warnings.warn("DEPRECATED: This function is no longer needed.")
+
+
+def after_scenario(*args, **kwargs):
+    warnings.warn("DEPRECATED: This function is no longer needed.")

--- a/behave_django/environment.py
+++ b/behave_django/environment.py
@@ -11,9 +11,18 @@ except ImportError:
 
 
 class BehaveHooksMixin(object):
+
+    """Provides methods that run during test execution
+
+    These methods are attached to behave via monkey patching.
+    """
     testcase_class = None
 
     def before_scenario(self, context):
+        """Method that runs before behave's before_scenario function
+
+        Sets up the test case, base_url, and the get_url() utility function.
+        """
         context.test = self.testcase_class()
         context.test.setUpClass()
         context.test()
@@ -27,10 +36,17 @@ class BehaveHooksMixin(object):
         context.get_url = get_url
 
     def load_fixtures(self, context):
+        """Method that runs immediately after behave's before_scenario function
+
+        If fixtures are found in context, loads the fixtures using the loaddata
+        management command.
+        """
         if getattr(context, 'fixtures', None):
             call_command('loaddata', *context.fixtures, verbosity=0)
 
     def after_scenario(self, context):
+        """Method that runs immediately after behave's after_scenario function
+        """
         context.test.tearDownClass()
         del context.test
 

--- a/behave_django/management/commands/behave.py
+++ b/behave_django/management/commands/behave.py
@@ -23,6 +23,8 @@ def get_new_options():
 
 
 def get_behave_options():
+    """Creates options for the behave management command based on behave"""
+
     new_options = get_new_options()
 
     conflicts = [

--- a/behave_django/runner.py
+++ b/behave_django/runner.py
@@ -9,10 +9,17 @@ from behave_django.testcase import (BehaviorDrivenTestCase,
 
 
 class BehaviorDrivenTestRunner(DiscoverRunner, BehaveHooksMixin):
+    """Test runner that uses the BehaviorDrivenTestCase"""
     testcase_class = BehaviorDrivenTestCase
 
 
 class ExistingDatabaseTestRunner(DiscoverRunner, BehaveHooksMixin):
+    """Test runner that uses the ExistingDatabaseTestCase
+
+    This test runner nullifies Django's test database setup methods. Using this
+    test runner would make your tests run with the default configured database
+    in settings.py.
+    """
     testcase_class = ExistingDatabaseTestCase
 
     def setup_databases(*args, **kwargs):

--- a/behave_django/runner.py
+++ b/behave_django/runner.py
@@ -9,11 +9,13 @@ from behave_django.testcase import (BehaviorDrivenTestCase,
 
 
 class BehaviorDrivenTestRunner(DiscoverRunner, BehaveHooksMixin):
+
     """Test runner that uses the BehaviorDrivenTestCase"""
     testcase_class = BehaviorDrivenTestCase
 
 
 class ExistingDatabaseTestRunner(DiscoverRunner, BehaveHooksMixin):
+
     """Test runner that uses the ExistingDatabaseTestCase
 
     This test runner nullifies Django's test database setup methods. Using this

--- a/behave_django/testcase.py
+++ b/behave_django/testcase.py
@@ -5,11 +5,23 @@ except ImportError:
 
 
 class BehaviorDrivenTestCase(StaticLiveServerTestCase):
+
+    """Test case attached to the context during behave execution
+
+    This test case prevents the regular tests from running.
+    """
+
     def runTest(*args, **kwargs):
         pass
 
 
 class ExistingDatabaseTestCase(BehaviorDrivenTestCase):
+
+    """ Test case used for the --use-existing-database setup
+
+    This test case prevents fixtures from being loaded to the database in use.
+    """
+
     def _fixture_setup(self):
         pass
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -44,3 +44,7 @@ Run ``python manage.py behave``
     3 steps passed, 0 failed, 0 skipped, 0 undefined
     Took.010s
     Destroying test database for alias 'default'...
+
+.. note::
+
+   Starting with version ``0.2.0``, you no longer need to insert the ``environment.before_scenario()`` and ``environment.after_scenario()`` functions in your ``environment.py`` file. The hooks are now included via monkey patching.

--- a/tests.py
+++ b/tests.py
@@ -75,19 +75,21 @@ class BehaveDjangoTestCase(unittest.TestCase):
 
     @patch('behave_django.management.commands.behave.behave_main', return_value=0)  # noqa
     @patch('behave_django.management.commands.behave.ExistingDatabaseTestRunner')  # noqa
-    def test_dont_create_db_with_dryrun(self, mock_behave_main,
-                                        mock_existing_database_runner):
+    def test_dont_create_db_with_dryrun(self,
+                                        mock_existing_database_runner,
+                                        mock_behave_main):
         run_management_command('behave', dry_run=True)
-        mock_behave_main.assert_called_once_with()
-        mock_existing_database_runner.assert_called_once_with(args=[])
+        mock_behave_main.assert_called_once_with(args=[])
+        mock_existing_database_runner.assert_called_once_with()
 
     @patch('behave_django.management.commands.behave.behave_main', return_value=0)  # noqa
     @patch('behave_django.management.commands.behave.ExistingDatabaseTestRunner')  # noqa
-    def test_dont_create_db_with_useexistingdb(self, mock_behave_main,
-                                               mock_existing_database_runner):
+    def test_dont_create_db_with_useexistingdb(self,
+                                               mock_existing_database_runner,
+                                               mock_behave_main):
         run_management_command('behave', use_existing_database=True)
-        mock_behave_main.assert_called_once_with()
-        mock_existing_database_runner.assert_called_once_with(args=[])
+        mock_behave_main.assert_called_once_with(args=[])
+        mock_existing_database_runner.assert_called_once_with()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
So I did a few things here:
- I rewrote two tests to use mocks. `python tests.py` now doesn't actually run behave, which is good for our test speeds.
- Added docstrings to things.
- Added a note in the installation docs about the not needing the `before/after_scenario()` functions anymore.
- Re-added the previous functions, and added a deprecation notice so that people who still use them don't get broken tests.
