### PR TITLE
Add python 3.5 test target with Django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - TOXENV=py33-django18
   - TOXENV=py34-django17
   - TOXENV=py34-django18
+  - TOXENV=py35-django18
 install:
   - pip install tox
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@
 envlist =
     py{26,27}-django14
     py{26,27,33,34}-django{15,16}
-    py{27,33,34}-django{17,18}
+    py{27,33,34}-django17
+    py{27,33,34,35}-django18
     docs
     flake8
 
@@ -17,6 +18,7 @@ basepython =
     py27: python2.7
     py33: python3.3
     py34: python3.4
+    py35: python3.5
 deps =
     pytest
     django14: Django>=1.4,<1.5


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.8/faq/install/#what-python-version-can-i-use-with-django
