### PR TITLE
Add note on providing initial data to documentation

### DIFF
--- a/behave_django/environment.py
+++ b/behave_django/environment.py
@@ -6,10 +6,10 @@ from django.core.management import call_command
 try:
     from django.shortcuts import resolve_url
 except ImportError:
-    # support Django 1.4, which has no resolve_url() yet
-    from django.shortcuts import redirect
-    resolve_url = lambda to, *args, **kwargs: \
-        redirect(to, *args, **kwargs)['Location']
+    def resolve_url(to, *args, **kwargs):
+        """Support Django 1.4, which has no built-in resolve_url()"""
+        from django.shortcuts import redirect
+        return redirect(to, *args, **kwargs)['Location']
 
 
 class BehaveHooksMixin(object):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-Welcome to behave-django's documentation!
-=========================================
+behave-django
+=============
 
 .. include:: ../README.rst
    :start-after: .. intro-marker

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -172,8 +172,15 @@ Of course, since ``context.fixtures`` is really just a list, you can
 mutate it however you want, it will only be processed upon leaving the
 ``before_scenario()`` function of your ``environment.py`` file.
 
+**NOTE:** If you provide initial data via Python code `using the ORM`_ you
+need to place these calls in ``before_scenario()`` even if the data is meant
+to be used on the whole feature.  This is because Django's
+``LiveServerTestCase`` resets the test database after each scenario.
+
+
 .. _django.shortcuts.redirect: https://docs.djangoproject.com/en/dev/topics/http/shortcuts/#redirect
 .. _factories: https://factoryboy.readthedocs.org/en/latest/
 .. _behave docs: https://pythonhosted.org/behave/behave.html#configuration-files
 .. |keepdb docs| replace:: More information about ``--keepdb``
 .. _keepdb docs: http://docs.python.org/library/optparse.html
+.. _using the ORM: https://docs.djangoproject.com/en/1.9/topics/testing/tools/#fixture-loading

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(join(dirname(__file__), 'README.rst')) as readme:
 # allow setup.py to be run from any path
 chdir(normpath(abspath(dirname(__file__))))
 
-import behave_django
+import behave_django  # noqa
 
 setup(
     name='behave-django',

--- a/test_project/wsgi.py
+++ b/test_project/wsgi.py
@@ -4,11 +4,11 @@ WSGI config for test_project project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
-
 import os
+from django.core.wsgi import get_wsgi_application
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_project.settings")
 
-from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()


### PR DESCRIPTION
- Add note on providing initial data via ORM
- Shorter main title of documentation (more concise = better reading)
- Address complaints of updated `flake8` (stricter checks)
